### PR TITLE
Update buienradar.py

### DIFF
--- a/buienradar/buienradar.py
+++ b/buienradar/buienradar.py
@@ -111,8 +111,8 @@ SENSOR_TYPES = {
     VISIBILITY: ['zichtmeters', to_int],
     WINDSPEED: ['windsnelheidMS', to_float2],
     WINDFORCE: ['windsnelheidBF', to_int],
-    WINDDIRECTION: ['windrichtingGR', to_int],
-    WINDAZIMUTH: ['windrichting', None],
+    WINDDIRECTION: ['windrichting', None],
+    WINDAZIMUTH: ['windrichtingGR', to_int],
     WINDGUST: ['windstotenMS', to_float2],
 }
 


### PR DESCRIPTION
In SENSOR_TYPES the wind direction (N, E, S, W, etc) and wind azimuth (0, 90, 180, 270, etc) were swapped.
Because 'windrichtingGR' in Dutch means 'wind direction in degrees' which corresponds with 'wind azimuth'.