### PR TITLE
Add url's as constants in new file, add radar image url

### DIFF
--- a/buienradar/buienradar_json.py
+++ b/buienradar/buienradar_json.py
@@ -60,6 +60,10 @@ from buienradar.constants import (
     WINDSPEED
 )
 
+from buienradar.urls import (
+    json_precipitation_forecast_url, JSON_FEED_URL,
+)
+
 # buienradar date format: '07/26/2017 15:50:00'
 # "2019-02-03T19:20:00",
 __DATE_FORMAT = '%Y-%m-%dT%H:%M:%S'
@@ -266,23 +270,12 @@ def parse_json_data(content, raincontent, latitude=52.091579,
 
 def __get_ws_data():
     """Get buienradar json data and return results."""
-    url = 'https://data.buienradar.nl/2.0/feed/json'
-
-    result = __get_url(url)
-
-    return result
+    return __get_url(JSON_FEED_URL)
 
 
 def __get_precipfc_data(latitude, longitude):
     """Get buienradar forecasted precipitation."""
-    url = 'https://gpsgadget.buienradar.nl/data/raintext?lat={}&lon={}'
-    # rounding coordinates prevents unnecessary redirects/calls
-    url = url.format(
-        round(latitude, 2),
-        round(longitude, 2)
-    )
-    result = __get_url(url)
-    return result
+    return __get_url(json_precipitation_forecast_url(latitude, longitude))
 
 
 def __get_url(url):

--- a/buienradar/buienradar_xml.py
+++ b/buienradar/buienradar_xml.py
@@ -48,6 +48,12 @@ from buienradar.constants import (
     WINDSPEED
 )
 
+from buienradar.urls import (
+    xml_precipitation_forecast_url,
+    XML_FEED_URL,
+    XML_SECONDARY_FEED_URL,
+)
+
 # key names in buienradar xml:
 __BRROOT = 'buienradarnl'
 __BRWEERGEGEVENS = 'weergegevens'
@@ -225,28 +231,19 @@ def __get_url(url):
 
 def __get_ws_data():
     """Get buienradar xml data and return results."""
-    url = 'https://xml.buienradar.nl/'
-
-    result = __get_url(url)
+    result = __get_url(XML_FEED_URL)
     if result[SUCCESS]:
         return result
 
     # try secondary url:
-    url = 'https://api.buienradar.nl/'
-    result = __get_url(url)
+    result = __get_url(XML_SECONDARY_FEED_URL)
 
     return result
 
 
 def __get_precipfc_data(latitude, longitude):
     """Get buienradar forecasted precipitation."""
-    url = 'http://gadgets.buienradar.nl/data/raintext/?lat={}&lon={}'
-    # rounding coordinates prevents unnecessary redirects/calls
-    url = url.format(
-        round(latitude, 2),
-        round(longitude, 2)
-    )
-    result = __get_url(url)
+    result = __get_url(xml_precipitation_forecast_url(latitude, longitude))
     return result
 
 

--- a/buienradar/urls.py
+++ b/buienradar/urls.py
@@ -1,0 +1,46 @@
+"""(functions that generate) URL's to access the buienradar api."""
+JSON_FEED_URL = 'https://data.buienradar.nl/2.0/feed/json'
+XML_FEED_URL = 'https://xml.buienradar.nl/'
+XML_SECONDARY_FEED_URL = 'https://api.buienradar.nl/'
+
+JSON_PRECIPITATION_URL_TEMPLATE = (
+    'https://gpsgadget.buienradar.nl/data/raintext?lat={lat}&lon={lon}'
+)
+XML_PRECIPITATION_URL_TEMPLATE = (
+    'http://gadgets.buienradar.nl/data/raintext/?lat={lat}&lon={lon}'
+)
+RADAR_URL_TEMPLATE = (
+    'https://api.buienradar.nl/image/1.0/RadarMapNL?w={w}&h={h}'
+)
+
+
+def xml_precipitation_forecast_url(latitude: float, longitude: float) -> str:
+    """Build URL to precipation forecast URL."""
+    return XML_PRECIPITATION_URL_TEMPLATE.format(
+        lat=round(latitude, 2),
+        lon=round(longitude, 2)
+    )
+
+
+def json_precipitation_forecast_url(latitude: float, longitude: float) \
+        -> str:
+    """Build URL to precipation forecast URL (used from json)."""
+    return JSON_PRECIPITATION_URL_TEMPLATE.format(
+        lat=round(latitude, 2),
+        lon=round(longitude, 2)
+    )
+
+
+def radar_url(width: int = 500, height: int = 512) -> str:
+    """
+    Build Buienradar radar image URL.
+
+    :param width width of output (120 <= w <= 700)
+    :param height height of output (120 <= h <= 765)
+    """
+    if width < 120 or width > 700:
+        raise ValueError("Illegal width, valid range: 120-700")
+    if height < 120 or height > 765:
+        raise ValueError("Illegal height, valid rang: 120-765")
+
+    return RADAR_URL_TEMPLATE.format(w=width, h=height)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Initialize the tests module."""
+# noqa

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,0 +1,126 @@
+"""Test for URL utilities."""
+from urllib.parse import urlparse, parse_qs
+
+from buienradar.urls import (
+    xml_precipitation_forecast_url,
+    json_precipitation_forecast_url,
+    radar_url,
+)
+
+
+def parse_qs_dict(url):
+    """
+    Parse a url and get a dictionary of query string elements in a dictionary.
+
+    Raises ValueError when an element is repeated (to safely return a dict of
+    strings instead of an dict of lists of strings.
+    """
+    token_dict = parse_qs(urlparse(url).query)
+    res = {}
+
+    for k, val in token_dict.items():
+        if len(val) > 1:
+            raise ValueError('Key {} has {} values'.format(k, len(val)))
+
+        res[k] = val[0]
+
+    return res
+
+
+def test_base_urls():
+    json_url = json_precipitation_forecast_url(1.23, 4.56)
+    xml_url = xml_precipitation_forecast_url(1.23, 4.56)
+
+    assert 'https://gpsgadget.buienradar.nl/data/raintext?' in json_url
+    assert 'http://gadgets.buienradar.nl/data/raintext/?' in xml_url
+
+    assert 'https://api.buienradar.nl/image/1.0/RadarMapNL?' in radar_url()
+
+
+def test_util():
+    """Test the utility function for dictionaries."""
+    try:
+        res = parse_qs_dict("http://example.org/?foo=1&bar=2")
+        assert res['foo'] == '1'
+        assert res['bar'] == '2'
+
+        parse_qs_dict("http://example.org/?foo=1&foo=2")
+        # Unreachable
+        assert False
+    except ValueError:
+        assert True
+
+
+def test_precipitation_forecast_url():
+    """Test both variations of the precipation forcecast URL-builder."""
+    for func in (xml_precipitation_forecast_url,
+                 json_precipitation_forecast_url):
+        # should return an url including identical 2-decimal lat/lon
+        url = func(1.23, 4.56)
+        tokens = parse_qs_dict(url)
+
+        assert tokens['lat'] == '1.23' and tokens['lon'] == '4.56'
+
+        # should return an url with truncated values
+        url = func(1.23456, 7.890123)
+        tokens = parse_qs_dict(url)
+
+        assert tokens['lat'] == '1.23' and tokens['lon'] == '7.89'
+
+        # that are rounded (up)
+        url = func(1.235, 7.890123)
+        tokens = parse_qs_dict(url)
+
+        assert tokens['lat'] == '1.24'
+
+
+def test_radar_url():
+    """
+    Test the generated radar url's.
+
+      * Check that it echoes the correct values in the result.
+      * Check that it excepts the extreme values of it's domain.
+
+    Pairs used are valid size and some minimum/maximum sizes.
+    """
+    # test default value:
+    tokens = parse_qs_dict(radar_url())
+    default_w = int(tokens['w'])
+    default_h = int(tokens['h'])
+
+    assert (default_w >= 120 and default_w <= 700 and
+            default_h >= 120 and default_h <= 700)
+
+    # test pairs:
+    for width, height in [(120, 120),
+                          (300, 300),
+                          (700, 700),
+                          (700, 765)]:
+        tokens = parse_qs_dict(radar_url(width, height))
+        assert tokens['w'] == str(width) and tokens['h'] == str(height)
+
+
+def test_radar_url_bounds():
+    """Test illegal values for radar image url."""
+    # outside of minimum/maximum width
+    for width in [119, 701]:
+        try:
+            radar_url(width, 125)
+            assert False
+        except ValueError:
+            assert True
+
+    # outside of minimum/maximum height
+    for height in [119, 766]:
+        try:
+            radar_url(125, height)
+            assert False
+        except ValueError:
+            assert True
+
+    # Check that it also raises when both are out of range
+    try:
+        radar_url(1234, 4567)
+        assert False
+    except ValueError:
+        assert True

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,16 @@
 [tox]
-envlist = py35,lint,typing
+envlist = py35, py36, py37, py38, lint, typing
 skip_missing_interpreters = True
 
 [testenv]
+basepython = {env:PYTHON3_PATH:python3}
 commands = py.test \
            --doctest-modules \
            --cov-report term-missing \
            --cov=buienradar \
            --cache-clear \
            --pep8 \
-           buienradar tests example {posargs}
+           buienradar tests {posargs}
 deps =
   requests
   pytest
@@ -20,7 +21,7 @@ usedevelop = True
 
 [testenv:lint]
 commands =
-    pylama setup.py buienradar tests example
+    pylama setup.py buienradar tests
     flake8 buienradar tests
 deps =
   isort
@@ -29,7 +30,7 @@ deps =
   pydocstyle
 
 [testenv:typing]
-basepython = python3.5
+basepython = {env:PYTHON3_PATH:python3}
 commands = mypy --ignore-missing-imports --follow-imports=skip buienradar
 deps = mypy
 


### PR DESCRIPTION
Some projects using this library (e.g. home assistant) use their own http session instead of using `__get_ws_data` to load the data since they want to use their own http session/library.

These projects need to refer to the URL's used by this project directly instead of the url being a constant provided by this library. Some projects even require these urls to be constants imported from a library (see review comment in https://github.com/home-assistant/home-assistant/pull/23358).

I added functions generating url's and tests for these, as well as a generator for the radar image url.

Please consider this change. I personally think it is a small stylistic improvement for this library and the library does depend on the exact API url being used.