### PR TITLE
Support parsing precipitation decimal values using `,` as decimal divider

### DIFF
--- a/buienradar/buienradar_json.py
+++ b/buienradar/buienradar_json.py
@@ -571,7 +571,8 @@ def __parse_precipfc_data(data, timeframe):
         #
         # Ter controle: een waarde van 77 is gelijk aan een neerslagintensiteit
         # van 0,1 mm/u.
-        mmu = 10**(float((int(val) - 109)) / 32)
+        val = float(val.replace(',', '.'))
+        mmu = 10**(float((val - 109)) / 32)
         totalrain = totalrain + float(mmu)
         numberoflines = numberoflines + 1
         index += 1

--- a/buienradar/buienradar_json.py
+++ b/buienradar/buienradar_json.py
@@ -572,7 +572,7 @@ def __parse_precipfc_data(data, timeframe):
         # Ter controle: een waarde van 77 is gelijk aan een neerslagintensiteit
         # van 0,1 mm/u.
         val = float(val.replace(',', '.'))
-        mmu = 10**(float((val - 109)) / 32)
+        mmu = 10**((val - 109) / 32)
         totalrain = totalrain + float(mmu)
         numberoflines = numberoflines + 1
         index += 1

--- a/buienradar/buienradar_xml.py
+++ b/buienradar/buienradar_xml.py
@@ -325,7 +325,8 @@ def __parse_precipfc_data(data, timeframe):
         #
         # Ter controle: een waarde van 77 is gelijk aan een neerslagintensiteit
         # van 0,1 mm/u.
-        mmu = 10**(float((int(val) - 109)) / 32)
+        val = float(val.replace(',', '.'))
+        mmu = 10 ** ((val - 109) / 32)
         totalrain = totalrain + float(mmu)
         numberoflines = numberoflines + 1
         index += 1

--- a/tests/test_parse_json.py
+++ b/tests/test_parse_json.py
@@ -338,6 +338,24 @@ def test_precip_fc5():
     assert (expect == result)
 
 
+def test_precip_decimal_values():
+    """Test parsing precipitation forecast data containing decimal values."""
+    def timeframe(minutes=0):
+        return (datetime.now() + timedelta(minutes=minutes)).strftime("%H:%M")
+
+    data = ""
+    data += "10,10|%s\n" % timeframe(0)
+    data += "100|%s\n" % timeframe(5)
+    data += "192,456798213|%s\n" % timeframe(10)
+    data += "55.55|%s\n" % timeframe(15)
+
+    result = __parse_precipfc_data(data, 20)
+    expect = {'total': 33.84, 'timeframe': 20, 'average': 135.36}
+
+    # test calling results in the loop close cleanly
+    assert (result == expect)
+
+
 def test_parse_timeframe():
     """Test loading and parsing xml file."""
     data = None

--- a/tests/test_parse_xml.py
+++ b/tests/test_parse_xml.py
@@ -336,6 +336,24 @@ def test_precip_fc5():
     assert (expect == result)
 
 
+def test_precip_decimal_values():
+    """Test parsing precipitation forecast data containing decimal values."""
+    def timeframe(minutes=0):
+        return (datetime.now() + timedelta(minutes=minutes)).strftime("%H:%M")
+
+    data = ""
+    data += "10,10|%s\n" % timeframe(0)
+    data += "100|%s\n" % timeframe(5)
+    data += "192,456798213|%s\n" % timeframe(10)
+    data += "55.55|%s\n" % timeframe(15)
+
+    result = __parse_precipfc_data(data, 20)
+    expect = {'total': 33.84, 'timeframe': 20, 'average': 135.36}
+
+    # test calling results in the loop close cleanly
+    assert (result == expect)
+
+
 def test_parse_timeframe():
     """Test loading and parsing xml file."""
     data = None


### PR DESCRIPTION
Apparently Buienradar can now send precipitation forecast values in a decimal notation, this was e.g. the precipitation forecast for The Hague tonight:
```
92,2678801510292|19:20
077|19:25
077|19:30
86,6329598612474|19:35
110,3245659250632|19:40
105,8988795837422|19:45
077|19:50
000|19:55
000|20:00
000|20:05
000|20:10
000|20:15
000|20:20
000|20:25
000|20:30
000|20:35
000|20:40
000|20:45
000|20:50
000|20:55
92,2678801510292|21:00
92,2678801510292|21:05
86,6329598612474|21:10
000|21:15
```

This PR adds support for parsing these decimal values.