### PR TITLE
make pytz.timezone(__TIMEZONE) constant

### DIFF
--- a/buienradar/buienradar_json.py
+++ b/buienradar/buienradar_json.py
@@ -67,6 +67,7 @@ from buienradar.urls import JSON_FEED_URL, json_precipitation_forecast_url
 # "2019-02-03T19:20:00",
 __DATE_FORMAT = '%Y-%m-%dT%H:%M:%S'
 __TIMEZONE = 'Europe/Amsterdam'
+__PYTZ_TIMEZONE = pytz.timezone(__TIMEZONE)
 
 __ACTUAL = "actual"
 __STATIONMEASUREMENTS = "stationmeasurements"
@@ -130,7 +131,7 @@ def __to_localdatetime(val):
     try:
         #  "timestamp": "2019-02-03T19:20:00",
         dt = datetime.strptime(val, __DATE_FORMAT)
-        dt = pytz.timezone(__TIMEZONE).localize(dt)
+        dt = __PYTZ_TIMEZONE.localize(dt)
         return dt
     except (AttributeError, ValueError, TypeError):
         return None

--- a/buienradar/buienradar_xml.py
+++ b/buienradar/buienradar_xml.py
@@ -81,7 +81,7 @@ __BRWINDKRACHT = 'windkracht'
 # buienradat date format: '07/26/2017 15:50:00'
 __DATE_FORMAT = '%m/%d/%Y %H:%M:%S'
 __TIMEZONE = 'Europe/Amsterdam'
-
+__PYTZ_TIMEZONE = pytz.timezone(__TIMEZONE)
 
 def __to_int(val):
     """Convert val into an integer value."""
@@ -113,7 +113,7 @@ def __to_localdatetime(val):
     """Convert val into a local datetime for tz Europe/Amsterdam."""
     try:
         dt = datetime.strptime(val, __DATE_FORMAT)
-        dt = pytz.timezone(__TIMEZONE).localize(dt)
+        dt = __PYTZ_TIMEZONE.localize(dt)
         return dt
     except (ValueError, TypeError):
         return None
@@ -398,7 +398,7 @@ def __parse_fc_data(fc_data):
         daysection = __BRDAYFC % daycnt
         if daysection in fc_data:
             tmpsect = fc_data[daysection]
-            fcdatetime = datetime.now(pytz.timezone(__TIMEZONE))
+            fcdatetime = datetime.now(__PYTZ_TIMEZONE)
             fcdatetime = fcdatetime.replace(hour=12,
                                             minute=0,
                                             second=0,


### PR DESCRIPTION
Home assistant using buienradar [reports error on blocking call](https://github.com/home-assistant/core/issues/118403) in inside event loop.

Proposed solution is to make `pytz.timezone(__TIMEZONE)` constant to prevent a locking call on each use.

This PR implements the change

```py
__PYTZ_TIMEZONE = pytz.timezone(__TIMEZONE)

        dt = datetime.strptime(val, __DATE_FORMAT)
        dt = __PYTZ_TIMEZONE.localize(dt)
        return dt
```
and test show the Home Assistant issue is resolved.